### PR TITLE
(feat:logout)

### DIFF
--- a/src/main/java/com/easytrip/backend/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/easytrip/backend/configuration/SecurityConfiguration.java
@@ -26,7 +26,7 @@ public class SecurityConfiguration {
     return http.csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(
             requests -> requests
-                .requestMatchers("/", "/members/sign-up", "/members/auth", "/members/login/**").permitAll())
+                .requestMatchers("/", "/members/sign-up", "/members/auth", "/members/login/**", "/members/logout").permitAll())
         .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(
             SessionCreationPolicy.STATELESS))
         .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class).build();

--- a/src/main/java/com/easytrip/backend/exception/impl/InvalidTokenException.java
+++ b/src/main/java/com/easytrip/backend/exception/impl/InvalidTokenException.java
@@ -3,7 +3,7 @@ package com.easytrip.backend.exception.impl;
 import com.easytrip.backend.exception.AbstractException;
 import org.springframework.http.HttpStatus;
 
-public class DuplicateNicknameException extends AbstractException {
+public class InvalidTokenException extends AbstractException {
 
   @Override
   public HttpStatus getHttpStatus() {
@@ -12,11 +12,11 @@ public class DuplicateNicknameException extends AbstractException {
 
   @Override
   public String getErrorCode() {
-    return "NICKNAME_DUPLICATE";
+    return "TOKEN_INVALID";
   }
 
   @Override
   public String getMessage() {
-    return "이미 존재하는 닉네임 입니다.";
+    return "유효하지 않은 토큰입니다.";
   }
 }

--- a/src/main/java/com/easytrip/backend/member/controller/MemberController.java
+++ b/src/main/java/com/easytrip/backend/member/controller/MemberController.java
@@ -8,9 +8,11 @@ import com.easytrip.backend.member.dto.TokenDto;
 import com.easytrip.backend.member.dto.request.LoginRequest;
 import com.easytrip.backend.member.dto.request.SignUpRequest;
 import com.easytrip.backend.member.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,7 +33,7 @@ public class MemberController {
     return ResponseEntity.ok(response);
   }
 
-  @PostMapping("/auth")
+  @GetMapping("/auth")
   public ResponseEntity<String> auth(@RequestParam(name = "email") String email,
       @RequestParam(name = "code") String code) {
     String response = memberService.auth(email, code);
@@ -56,4 +58,13 @@ public class MemberController {
     return ResponseEntity.ok(response);
   }
 
+  @DeleteMapping("/logout")
+  public ResponseEntity<String> logout(HttpServletRequest request) {
+    String accessToken = request.getHeader("Authorization");
+    if (accessToken != null && accessToken.startsWith("Bearer ")) {
+      accessToken = accessToken.substring(7); // "Bearer " 이후의 토큰 값만 추출
+    }
+    memberService.logout(accessToken);
+    return ResponseEntity.ok("로그아웃 완료");
+  }
 }

--- a/src/main/java/com/easytrip/backend/member/service/MemberService.java
+++ b/src/main/java/com/easytrip/backend/member/service/MemberService.java
@@ -18,4 +18,6 @@ public interface MemberService {
   TokenDto naverLogin(String code, PlatForm platForm);
 
   TokenDto kakaoLogin(String code, PlatForm platForm);
+
+  void logout(String accessToken);
 }


### PR DESCRIPTION
로그아웃 기능을 구현했습니다.
헤더에 accessToken을 받아 로그아웃을 진행합니다.
토큰을 검증하고 문제가 없을 때 Redis에 저장되어있는 해당 회원의 refreshToken을 삭제하고 accessToken을 저장해 해당 accessToken이 사용되지 못하게 합니다.